### PR TITLE
Change module name after move from projectriff-samples

### DIFF
--- a/.github/workflows/stage.sh
+++ b/.github/workflows/stage.sh
@@ -9,4 +9,4 @@ readonly git_sha=$(git rev-parse HEAD)
 readonly git_timestamp=$(TZ=UTC git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
 readonly slug=${version}-${git_timestamp}-${git_sha:0:16}
 
-ko publish -P -t ${slug} github.com/projectriff-samples/http-source/cmd
+ko publish -P -t ${slug} github.com/projectriff/http-source/cmd

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test: fmt vet ## Run tests
 
 .PHONY: compile
 compile: ko fmt vet ## Compile target binaries
-	$(KO) publish -P -L github.com/projectriff-samples/http-source/cmd
+	$(KO) publish -P -L github.com/projectriff/http-source/cmd
 
 # Run go fmt against code
 .PHONY: fmt

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ and sending messages to output stream(s) configured _via_ environment variables.
 Having a working go 1.13+ installation and ko[https://github.com/google/ko] installed, simply run
 [source, bash]
 ----
-ko publish github.com/projectriff-samples/http-source/cmd
+ko publish github.com/projectriff/http-source/cmd
 ----
 
 This will publish an image whose coordinates should be noted down for further use, `<image>` below.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/projectriff-samples/http-source/pkg"
+	"github.com/projectriff/http-source/pkg"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/projectriff-samples/http-source
+module github.com/projectriff/http-source
 
 go 1.13
 


### PR DESCRIPTION
before: `github.com/projectriff-samples/http-source`  
after: `github.com/projectriff/http-source`