### PR TITLE
Configure source with stream bindings.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,15 +10,11 @@ import (
 
 func main() {
 
-	requireEnvVars("OUTPUTS", "OUTPUT_CONTENT_TYPES")
+	requireEnvVars("OUTPUTS", "CNB_BINDINGS")
 
 	outputs := strings.Split(os.Getenv("OUTPUTS"), ",")
-	contentTypes := strings.Split(os.Getenv("OUTPUT_CONTENT_TYPES"), ",")
-	if len(outputs) != len(contentTypes) {
-		panic(fmt.Sprintf("OUTPUTS and OUTPUT_CONTENT_TYPES lists should be of the same size. %d != %d", len(outputs), len(contentTypes)))
-	}
 
-	s, err := pkg.NewSource(outputs, contentTypes)
+	s, err := pkg.NewSource(os.Getenv("CNB_BINDINGS"), outputs)
 	if err != nil {
 		panic(err)
 	}

--- a/config/deployment.yaml
+++ b/config/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: http-source
+spec:
+  selector:
+    matchLabels:
+      app: http-source
+  template:
+    metadata:
+      labels:
+        app: http-source
+    spec:
+      containers:
+      - env:
+        - name: OUTPUTS
+          value: "/foo=output_0000,/bar=output_0001,/other-foo=output_0000,/same-stream=output_0002"
+        - name: CNB_BINDINGS
+          value: "/some-root"
+        image: github.com/projectriff/http-source/cmd
+        name: http-source
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+          - name: out-stream-binding-secret
+            mountPath: "/some-root/output_0000/secret"
+            readOnly: true
+          - name: out2-stream-binding-secret
+            mountPath: "/some-root/output_0001/secret"
+            readOnly: true
+          - name: out-stream-binding-secret
+            mountPath: "/some-root/output_0002/secret"
+            readOnly: true
+          - name: out-stream-binding-metadata
+            mountPath: "/some-root/output_0000/metadata"
+            readOnly: true
+          - name: out2-stream-binding-metadata
+            mountPath: "/some-root/output_0001/metadata"
+            readOnly: true
+          - name: out-stream-binding-metadata
+            mountPath: "/some-root/output_0002/metadata"
+            readOnly: true
+      volumes:
+        - name: out-stream-binding-secret
+          secret:
+            secretName: out-stream-binding-secret
+        - name: out2-stream-binding-secret
+          secret:
+            secretName: out2-stream-binding-secret
+        - name: out-stream-binding-metadata
+          configMap:
+            name: out-stream-binding-metadata
+        - name: out2-stream-binding-metadata
+          configMap:
+            name: out2-stream-binding-metadata
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-source
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: http-source
+  type: ClusterIP

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/projectriff/http-source
 go 1.13
 
 require github.com/projectriff/stream-client-go v0.0.0-20191104145951-d4217bd650fb
+
+replace github.com/projectriff/stream-client-go => ../stream-client-go


### PR DESCRIPTION
Fixes #4

The configuration of the source is now (\<path\>=\<binding\>)+

The config/ directory showcases a manual volume+mounts scenario
that covers all cases of the cardinalities that need to be supported.

The names used there (output_xxxx) are similar to the ones used in the
processor case.

```
+---------------+         +-------------+            +---------+
|               +---------+             +------------+         |
|      Path     | N     1 |   Binding   | N        1 | Stream  |
|               |         |             |            |         |
+---------------+         +-------------+            +---------+
```